### PR TITLE
Maintenance/font formatting

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,41 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main", "develop" ] # run when code is pushed to main or develop
+  pull_request:
+    branches: [ "main", "develop" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+     # Step 1: Check out the repository code so the runner can access it
+    - uses: actions/checkout@v4
+    
+    # Step 2: Install and configure Java Development Kit (JDK)
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'        # JHotDraw requires Java 11
+        distribution: 'temurin'   # Temurin OpenJDK distribution
+        cache: maven              # Enables caching of Maven dependencies to speed up builds
+        
+    # Step 3: Build the project using Maven
+    - name: Build with Maven
+      run: mvn -B verify --file pom.xml
+    # verify runs the full Maven lifecycle including compilation and tests
+
+    # Step 4: Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,7 +33,7 @@ jobs:
         
     # Step 3: Build the project using Maven
     - name: Build with Maven
-      run: mvn -B verify --file pom.xml
+      run: mvn -B verify --settings .maven-settings.xml
     # verify runs the full Maven lifecycle including compilation and tests
 
     # Step 4: Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive

--- a/.maven-settings.xml
+++ b/.maven-settings.xml
@@ -1,0 +1,15 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <!-- Authentication for GitHub Packages -->
+    <servers>
+        <server>
+            <id>github</id>
+            <username>${env.GITHUB_ACTOR}</username>
+            <password>${env.GITHUB_TOKEN}</password>
+        </server>
+    </servers>
+
+</settings>

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@
 ## History 
 
 This is a fork of jhotdraw from http://sourceforge.net/projects/jhotdraw.
+
+## Group 12 - IntroLab test branch


### PR DESCRIPTION
I could not run the project locally on java 17, so, I downgraded to 11. this is why java is set up to version 11 in maven.yml

These tasks were done for this PR:

Go to [Building and testing Java with Maven]
Add a *.yml file to your repository path <YOUR_PROJECT>/.github/workflows/ to tell
GitHub Actions CI what to do.
Configure the *.yml to automatically build your project for each pull request (use maven).
To use shared jars from GitHub Packages you need create a .maven-settings.xml file in
the project root folder, see [Working with the Apache Maven registry]
Configure the *.yml to execute tests automatically.