### PR TITLE
Add Maven CI workflow and settings

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,23 @@
+name: Java CI with Maven
+
+on:
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+
+    - name: Build and Test with Maven
+      run: mvn clean install -s maven-settings.xml

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -1,0 +1,11 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>github</id>
+            <username>${{ github.actor }}</username>
+            <password>${{ secrets.GITHUB_TOKEN }}</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
Add a GitHub Actions workflow to run Maven build and tests on pull requests to main/master. The workflow checks out code, sets up Temurin JDK 11, enables Maven cache, and runs `mvn clean install -s maven-settings.xml`. Also add maven-settings.xml with a <server> entry that references `${{ github.actor }}` and `${{ secrets.GITHUB_TOKEN }}` to allow authenticated access to GitHub Packages.