### PR TITLE
Arrange: extract ZOrderUndoableEdit + tests + CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - feature/Send-To-Front-or-Back
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build and test
+        run: mvn -B verify -s .maven-settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.maven-settings.xml
+++ b/.maven-settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0
+                              https://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+</settings>

--- a/concept-location-arrange.md
+++ b/concept-location-arrange.md
@@ -1,0 +1,88 @@
+# Concept Location: Arrange (Send to Front / Send to Back) Feature
+
+## Method
+
+The Arrange feature was located using source-code search in VS Code and can be confirmed at runtime with the VS Code Java Debugger.  
+The selected change request is:
+
+**Arrange: Send to Front and Send to Back Actions**
+
+The project was searched for the strings:
+
+- `bringToFront`
+- `sendToBack`
+- `edit.bringToFront`
+
+This revealed the controller classes, model interfaces, and concrete drawing/container implementations involved in the feature.
+
+---
+
+## Concept Location Steps
+
+1. Searched for **"Send to Front"** in the project.
+2. The initial hits were in `Labels.properties`, which only contain UI labels.
+3. Then searched for:
+   - `bringToFront`
+   - `sendToBack`
+4. This revealed the main feature-related classes:
+   - `BringToFrontAction`
+   - `SendToBackAction`
+   - `Drawing`
+   - `QuadTreeDrawing`
+   - `AbstractCompositeFigure`
+   - `QuadTreeCompositeFigure`
+5. The search results showed that the action classes delegate the request to the drawing model, where the actual z-order change is performed.
+
+---
+
+## Observed Feature Structure
+
+The feature starts from controller/action classes and then delegates into the drawing model:
+
+- `BringToFrontAction` handles the UI action for **Send to Front**
+- `SendToBackAction` handles the UI action for **Send to Back**
+- These actions operate on the selected `Figure` objects in the current `DrawingView`
+- The actual reordering logic is implemented in domain/model classes such as `Drawing` and composite figure classes
+
+This means the feature begins in the UI layer, but the actual domain behavior is performed in the model layer.
+
+---
+
+## Initial Set of Classes
+
+| # | Domain Class | Module | Responsibility |
+|---|---|---|---|
+| 1 | `Figure` | jhotdraw-core | Represents a drawable object in the drawing. It is the domain object whose z-order is changed when the user sends it to the front or back. |
+| 2 | `Drawing` | jhotdraw-core | Core drawing model interface. Declares operations such as `bringToFront(Figure)` and `sendToBack(Figure)` which define the feature at the model level. |
+| 3 | `QuadTreeDrawing` | jhotdraw-core | Concrete implementation of `Drawing`. Performs the actual reordering of figures in the drawing and updates the drawing state after the change. |
+| 4 | `AbstractCompositeFigure` | jhotdraw-core | Base container for child figures. Supports reordering of child figures inside grouped/container figures by changing their internal order. |
+| 5 | `QuadTreeCompositeFigure` | jhotdraw-core | Concrete composite/container implementation. Applies the same front/back ordering behavior for figures stored inside a composite structure. |
+
+---
+
+## Supporting Controller Classes
+
+The following classes are part of the feature flow, but they act mainly as controllers rather than core domain classes:
+
+| # | Class | Module | Responsibility |
+|---|---|---|---|
+| 1 | `BringToFrontAction` | jhotdraw-core | Controller action for the **Send to Front** command. Retrieves the selected figures and delegates the operation to the drawing model. |
+| 2 | `SendToBackAction` | jhotdraw-core | Controller action for the **Send to Back** command. Retrieves the selected figures and delegates the operation to the drawing model. |
+
+These classes are useful for tracing the feature, but the main domain logic belongs to the model classes listed in the previous table.
+
+---
+
+## Intended Runtime Flow
+
+When the feature works, the execution flow is conceptually:
+
+```text
+User clicks Arrange > Send to Front
+  -> BringToFrontAction
+    -> gets selected figures from the current DrawingView
+    -> delegates to the Drawing model
+      -> Drawing.bringToFront(figure)
+        -> concrete implementation reorders the figure
+           (e.g. in QuadTreeDrawing or a composite figure container)
+        -> drawing is refreshed

--- a/jhotdraw-core/pom.xml
+++ b/jhotdraw-core/pom.xml
@@ -73,6 +73,10 @@
 					</dependency>
 				</dependencies>
 				<configuration>
+					<!-- All tests in this module are JUnit/JGiven (the legacy AbstractFigureNGTest
+					     was migrated from TestNG to JUnit 4), so the junit47 provider runs every
+					     suite. The *NGTest.java include is kept so the migrated file is still picked
+					     up by its original name. argLine opens java.lang for JGiven on JDK 16+. -->
 					<includes>
 						<include>**/*Test.java</include>
 						<include>**/*NGTest.java</include>

--- a/jhotdraw-core/pom.xml
+++ b/jhotdraw-core/pom.xml
@@ -35,10 +35,51 @@
 			<version>6.8.21</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.tngtech.jgiven</groupId>
+			<artifactId>jgiven-junit</artifactId>
+			<version>1.2.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.23.1</version>
+			<scope>test</scope>
+		</dependency>
 	 <dependency>
 	  <groupId>${project.groupId}</groupId>
 	  <artifactId>jhotdraw-actions</artifactId>
 	  <version>${project.version}</version>
 	 </dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.maven.surefire</groupId>
+						<artifactId>surefire-junit47</artifactId>
+						<version>2.22.2</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<includes>
+						<include>**/*Test.java</include>
+						<include>**/*NGTest.java</include>
+					</includes>
+					<argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/BringToFrontAction.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/BringToFrontAction.java
@@ -8,8 +8,11 @@
 package org.jhotdraw.draw.action;
 
 import org.jhotdraw.draw.figure.Figure;
-import java.util.*;
-import org.jhotdraw.draw.*;
+import java.util.Collection;
+import java.util.LinkedList;
+import org.jhotdraw.draw.Drawing;
+import org.jhotdraw.draw.DrawingEditor;
+import org.jhotdraw.draw.DrawingView;
 import org.jhotdraw.util.ResourceBundleUtil;
 
 /**

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/BringToFrontAction.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/BringToFrontAction.java
@@ -9,12 +9,16 @@ package org.jhotdraw.draw.action;
 
 import org.jhotdraw.draw.figure.Figure;
 import java.util.*;
-import javax.swing.undo.*;
 import org.jhotdraw.draw.*;
 import org.jhotdraw.util.ResourceBundleUtil;
 
 /**
- * ToFrontAction.
+ * UI action for <em>Arrange &rarr; Send to Front</em>. Collects the figures currently selected in the
+ * active {@link DrawingView} and raises them to the top of the drawing's z-order by delegating to the
+ * {@link Drawing} model, then registers a {@link ZOrderUndoableEdit} so the operation can be undone.
+ *
+ * <p>Depends only on the {@code Drawing} interface (not a concrete implementation), keeping the UI
+ * layer decoupled from the model (Dependency Inversion Principle).
  *
  * @author Werner Randelshofer
  * @version $Id$
@@ -35,35 +39,25 @@ public class BringToFrontAction extends AbstractSelectedAction {
         updateEnabledState();
     }
 
+    /**
+     * Brings the current selection to the front and records an undoable edit. The edit is created with
+     * {@code toFront == true}, so redo brings to front and undo sends to back.
+     */
     @Override
     public void actionPerformed(java.awt.event.ActionEvent e) {
         final DrawingView view = getView();
         final LinkedList<Figure> figures = new LinkedList<>(view.getSelectedFigures());
         bringToFront(view, figures);
-        fireUndoableEditHappened(new AbstractUndoableEdit() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public String getPresentationName() {
-                ResourceBundleUtil labels
-                        = ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels");
-                return labels.getTextProperty(ID);
-            }
-
-            @Override
-            public void redo() throws CannotRedoException {
-                super.redo();
-                BringToFrontAction.bringToFront(view, figures);
-            }
-
-            @Override
-            public void undo() throws CannotUndoException {
-                super.undo();
-                SendToBackAction.sendToBack(view, figures);
-            }
-        });
+        fireUndoableEditHappened(new ZOrderUndoableEdit(view, figures, ID, true));
     }
 
+    /**
+     * Brings the given figures to the front of the drawing, preserving their relative order (they are
+     * sorted by current z-order before each is moved to the top).
+     *
+     * @param view    the drawing view whose drawing is modified
+     * @param figures the figures to bring to front
+     */
     public static void bringToFront(DrawingView view, Collection<Figure> figures) {
         Drawing drawing = view.getDrawing();
         for (Figure figure : drawing.sort(figures)) {

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/SendToBackAction.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/SendToBackAction.java
@@ -9,12 +9,18 @@ package org.jhotdraw.draw.action;
 
 import org.jhotdraw.draw.figure.Figure;
 import java.util.*;
-import javax.swing.undo.*;
 import org.jhotdraw.draw.*;
 import org.jhotdraw.util.ResourceBundleUtil;
 
 /**
- * SendToBackAction.
+ * UI action for <em>Arrange &rarr; Send to Back</em>. Collects the figures currently selected in the
+ * active {@link DrawingView} and lowers them to the bottom of the drawing's z-order by delegating to
+ * the {@link Drawing} model, then registers a {@link ZOrderUndoableEdit} so the operation can be
+ * undone.
+ *
+ * <p>Mirror image of {@link BringToFrontAction}. Note the pre-existing asymmetry: unlike
+ * {@code bringToFront}, this path does not sort the figures before moving them &mdash; see the inline
+ * sorting caveat in {@link #sendToBack}.
  *
  * @author Werner Randelshofer
  * @version $Id$
@@ -35,35 +41,24 @@ public class SendToBackAction extends AbstractSelectedAction {
         updateEnabledState();
     }
 
+    /**
+     * Sends the current selection to the back and records an undoable edit. The edit is created with
+     * {@code toFront == false}, so redo sends to back and undo brings to front.
+     */
     @Override
     public void actionPerformed(java.awt.event.ActionEvent e) {
         final DrawingView view = getView();
         final LinkedList<Figure> figures = new LinkedList<>(view.getSelectedFigures());
         sendToBack(view, figures);
-        fireUndoableEditHappened(new AbstractUndoableEdit() {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public String getPresentationName() {
-                ResourceBundleUtil labels
-                        = ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels");
-                return labels.getTextProperty(ID);
-            }
-
-            @Override
-            public void redo() throws CannotRedoException {
-                super.redo();
-                SendToBackAction.sendToBack(view, figures);
-            }
-
-            @Override
-            public void undo() throws CannotUndoException {
-                super.undo();
-                BringToFrontAction.bringToFront(view, figures);
-            }
-        });
+        fireUndoableEditHappened(new ZOrderUndoableEdit(view, figures, ID, false));
     }
 
+    /**
+     * Sends the given figures to the back of the drawing.
+     *
+     * @param view    the drawing view whose drawing is modified
+     * @param figures the figures to send to back
+     */
     public static void sendToBack(DrawingView view, Collection<Figure> figures) {
         Drawing drawing = view.getDrawing();
         for (Figure figure : figures) { // XXX Shouldn't the figures be sorted here back to front?

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/SendToBackAction.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/SendToBackAction.java
@@ -8,8 +8,11 @@
 package org.jhotdraw.draw.action;
 
 import org.jhotdraw.draw.figure.Figure;
-import java.util.*;
-import org.jhotdraw.draw.*;
+import java.util.Collection;
+import java.util.LinkedList;
+import org.jhotdraw.draw.Drawing;
+import org.jhotdraw.draw.DrawingEditor;
+import org.jhotdraw.draw.DrawingView;
 import org.jhotdraw.util.ResourceBundleUtil;
 
 /**

--- a/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/ZOrderUndoableEdit.java
+++ b/jhotdraw-core/src/main/java/org/jhotdraw/draw/action/ZOrderUndoableEdit.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2003-2008 The authors and contributors of JHotDraw.
+ * You may not use, copy or modify this file, except in compliance with the
+ * accompanying license terms.
+ */
+package org.jhotdraw.draw.action;
+
+import org.jhotdraw.draw.figure.Figure;
+import java.util.LinkedList;
+import javax.swing.undo.AbstractUndoableEdit;
+import javax.swing.undo.CannotRedoException;
+import javax.swing.undo.CannotUndoException;
+import org.jhotdraw.draw.DrawingView;
+import org.jhotdraw.util.ResourceBundleUtil;
+
+/**
+ * Extracted from the duplicated anonymous AbstractUndoableEdit in BringToFrontAction and
+ * SendToBackAction. Encapsulates the undo/redo logic for z-order operations.
+ *
+ * <p>When {@code toFront} is {@code true}, redo brings figures to front and undo sends them to
+ * back. When {@code false}, the directions are reversed.
+ */
+class ZOrderUndoableEdit extends AbstractUndoableEdit {
+
+    private static final long serialVersionUID = 1L;
+
+    private final DrawingView view;
+    private final LinkedList<Figure> figures;
+    private final String labelId;
+    private final boolean toFront;
+
+    /**
+     * @param view     the view whose drawing is reordered on redo/undo
+     * @param figures  the figures whose z-order is changed
+     * @param labelId  resource-bundle key for the undo presentation name
+     * @param toFront  {@code true} for a bring-to-front edit (redo = front, undo = back);
+     *                 {@code false} for a send-to-back edit (redo = back, undo = front)
+     */
+    ZOrderUndoableEdit(DrawingView view, LinkedList<Figure> figures, String labelId, boolean toFront) {
+        this.view = view;
+        this.figures = figures;
+        this.labelId = labelId;
+        this.toFront = toFront;
+    }
+
+    @Override
+    public String getPresentationName() {
+        return ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels").getTextProperty(labelId);
+    }
+
+    @Override
+    public void redo() throws CannotRedoException {
+        super.redo();
+        if (toFront) {
+            BringToFrontAction.bringToFront(view, figures);
+        } else {
+            SendToBackAction.sendToBack(view, figures);
+        }
+    }
+
+    @Override
+    public void undo() throws CannotUndoException {
+        super.undo();
+        if (toFront) {
+            SendToBackAction.sendToBack(view, figures);
+        } else {
+            BringToFrontAction.bringToFront(view, figures);
+        }
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/QuadTreeDrawingTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/QuadTreeDrawingTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026 The authors and contributors of JHotDraw.
+ * You may not use, copy or modify this file, except in compliance with the
+ * accompanying license terms.
+ */
+package org.jhotdraw.draw;
+
+import org.jhotdraw.draw.figure.AbstractFigure;
+import org.jhotdraw.draw.figure.Figure;
+
+import java.awt.Graphics2D;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * JUnit 4 tests for QuadTreeDrawing.bringToFront and QuadTreeDrawing.sendToBack.
+ *
+ * Lab 5 — TestLab1 (Software Maintenance portfolio).
+ */
+public class QuadTreeDrawingTest {
+
+    private QuadTreeDrawing drawing;
+    private Figure figureA;
+    private Figure figureB;
+    private Figure figureC;
+
+    @Before
+    public void setUp() {
+        drawing = new QuadTreeDrawing();
+        figureA = new StubFigure();
+        figureB = new StubFigure();
+        figureC = new StubFigure();
+        drawing.add(figureA);
+        drawing.add(figureB);
+        drawing.add(figureC);
+    }
+
+    // --- bringToFront ---
+
+    @Test
+    public void bringToFront_movesMiddleFigureToLast() {
+        drawing.bringToFront(figureB);
+        List<Figure> children = drawing.getChildren();
+        assertEquals(figureB, children.get(children.size() - 1));
+    }
+
+    @Test
+    public void bringToFront_movesBackFigureToLast() {
+        drawing.bringToFront(figureA);
+        List<Figure> children = drawing.getChildren();
+        assertEquals(figureA, children.get(children.size() - 1));
+    }
+
+    @Test
+    public void bringToFront_alreadyAtFront_figureRemainsLast() {
+        drawing.bringToFront(figureC);
+        List<Figure> children = drawing.getChildren();
+        assertEquals(figureC, children.get(children.size() - 1));
+    }
+
+    @Test
+    public void bringToFront_notInDrawing_orderUnchanged() {
+        Figure outsider = new StubFigure();
+        List<Figure> before = drawing.getChildren();
+        drawing.bringToFront(outsider);
+        assertEquals(before, drawing.getChildren());
+    }
+
+    @Test
+    public void bringToFront_childCountUnchanged() {
+        int before = drawing.getChildCount();
+        drawing.bringToFront(figureA);
+        assert drawing.getChildCount() == before : "child count must not change after bringToFront";
+        assertEquals(before, drawing.getChildCount());
+    }
+
+    // --- sendToBack ---
+
+    @Test
+    public void sendToBack_movesMiddleFigureToFirst() {
+        drawing.sendToBack(figureB);
+        assertEquals(figureB, drawing.getChild(0));
+    }
+
+    @Test
+    public void sendToBack_movesFrontFigureToFirst() {
+        drawing.sendToBack(figureC);
+        assertEquals(figureC, drawing.getChild(0));
+    }
+
+    @Test
+    public void sendToBack_alreadyAtBack_figureRemainsFirst() {
+        drawing.sendToBack(figureA);
+        assertEquals(figureA, drawing.getChild(0));
+    }
+
+    @Test
+    public void sendToBack_notInDrawing_orderUnchanged() {
+        Figure outsider = new StubFigure();
+        List<Figure> before = drawing.getChildren();
+        drawing.sendToBack(outsider);
+        assertEquals(before, drawing.getChildren());
+    }
+
+    @Test
+    public void sendToBack_childCountUnchanged() {
+        int before = drawing.getChildCount();
+        drawing.sendToBack(figureC);
+        assert drawing.getChildCount() == before : "child count must not change after sendToBack";
+        assertEquals(before, drawing.getChildCount());
+    }
+
+    // -------------------------------------------------------------------------
+    // Minimal Figure stub — returns a simple rectangle for spatial operations.
+    // All other methods are no-ops so no Swing or external context is needed.
+    // -------------------------------------------------------------------------
+    static class StubFigure extends AbstractFigure {
+
+        @Override
+        public void draw(Graphics2D g) {
+        }
+
+        @Override
+        public Rectangle2D.Double getBounds() {
+            return new Rectangle2D.Double(0, 0, 10, 10);
+        }
+
+        @Override
+        public Rectangle2D.Double getDrawingArea() {
+            return new Rectangle2D.Double(0, 0, 10, 10);
+        }
+
+        @Override
+        public Rectangle2D.Double getDrawingArea(double factor) {
+            return new Rectangle2D.Double(0, 0, 10, 10);
+        }
+
+        @Override
+        public boolean contains(Point2D.Double p) {
+            return false;
+        }
+
+        @Override
+        public Object getTransformRestoreData() {
+            return null;
+        }
+
+        @Override
+        public void restoreTransformTo(Object restoreData) {
+        }
+
+        @Override
+        public void transform(AffineTransform tx) {
+        }
+
+        @Override
+        public <T> void set(AttributeKey<T> key, T value) {
+        }
+
+        @Override
+        public <T> T get(AttributeKey<T> key) {
+            return null;
+        }
+
+        @Override
+        public Map<AttributeKey<?>, Object> getAttributes() {
+            return java.util.Collections.emptyMap();
+        }
+
+        @Override
+        public Object getAttributesRestoreData() {
+            return null;
+        }
+
+        @Override
+        public void restoreAttributesTo(Object restoreData) {
+        }
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/bdd/ArrangeZOrderTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/bdd/ArrangeZOrderTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 The authors and contributors of JHotDraw.
+ */
+package org.jhotdraw.draw.bdd;
+
+import com.tngtech.jgiven.junit.ScenarioTest;
+import org.junit.Test;
+
+/**
+ * BDD scenarios for the Arrange (Send to Front / Send to Back) feature.
+ *
+ * <p>Uses JGiven stage classes (GivenDrawing, WhenArrange, ThenZOrder) and AssertJ assertions,
+ * all operating at the domain model level (no Swing required).
+ *
+ * Lab 6 — BDDLab (Software Maintenance portfolio).
+ */
+public class ArrangeZOrderTest extends ScenarioTest<GivenDrawing, WhenArrange, ThenZOrder> {
+
+    @Test
+    public void send_figure_to_front() {
+        given().a_drawing_with_three_figures_A_B_C();
+        when().figure_A_is_sent_to_the_front();
+        then().figure_A_is_at_the_front();
+    }
+
+    @Test
+    public void send_figure_to_back() {
+        given().a_drawing_with_three_figures_A_B_C();
+        when().figure_C_is_sent_to_the_back();
+        then().figure_C_is_at_the_back();
+    }
+
+    @Test
+    public void sending_front_figure_to_front_is_a_no_op() {
+        given().a_drawing_with_three_figures_A_B_C();
+        when().figure_C_is_sent_to_the_front();
+        then().figure_C_is_still_at_the_front();
+    }
+
+    @Test
+    public void sending_back_figure_to_back_is_a_no_op() {
+        given().a_drawing_with_three_figures_A_B_C();
+        when().figure_A_is_sent_to_the_back();
+        then().figure_A_is_still_at_the_back();
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/bdd/GivenDrawing.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/bdd/GivenDrawing.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 The authors and contributors of JHotDraw.
+ * You may not use, copy or modify this file, except in compliance with the
+ * accompanying license terms.
+ */
+package org.jhotdraw.draw.bdd;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.annotation.ScenarioState.Resolution;
+import org.jhotdraw.draw.QuadTreeDrawing;
+import org.jhotdraw.draw.figure.Figure;
+
+/**
+ * JGiven Given-stage: sets up a QuadTreeDrawing with stub figures.
+ * Lab 6 — BDDLab (Software Maintenance portfolio).
+ */
+public class GivenDrawing extends Stage<GivenDrawing> {
+
+    @ProvidedScenarioState(resolution = Resolution.NAME)
+    QuadTreeDrawing drawing;
+
+    @ProvidedScenarioState(resolution = Resolution.NAME)
+    Figure figureA;
+
+    @ProvidedScenarioState(resolution = Resolution.NAME)
+    Figure figureB;
+
+    @ProvidedScenarioState(resolution = Resolution.NAME)
+    Figure figureC;
+
+    public GivenDrawing a_drawing_with_three_figures_A_B_C() {
+        drawing = new QuadTreeDrawing();
+        figureA = new StubFigure();
+        figureB = new StubFigure();
+        figureC = new StubFigure();
+        drawing.add(figureA);
+        drawing.add(figureB);
+        drawing.add(figureC);
+        return self();
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/bdd/StubFigure.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/bdd/StubFigure.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 The authors and contributors of JHotDraw.
+ */
+package org.jhotdraw.draw.bdd;
+
+import org.jhotdraw.draw.AttributeKey;
+import org.jhotdraw.draw.figure.AbstractFigure;
+
+import java.awt.Graphics2D;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Minimal Figure stub for use in BDD stage classes.
+ * Returns a fixed 10x10 rectangle for all spatial queries; all other methods are no-ops.
+ */
+class StubFigure extends AbstractFigure {
+
+    @Override public void draw(Graphics2D g) {}
+
+    @Override
+    public Rectangle2D.Double getBounds() {
+        return new Rectangle2D.Double(0, 0, 10, 10);
+    }
+
+    @Override
+    public Rectangle2D.Double getDrawingArea() {
+        return new Rectangle2D.Double(0, 0, 10, 10);
+    }
+
+    @Override
+    public Rectangle2D.Double getDrawingArea(double factor) {
+        return new Rectangle2D.Double(0, 0, 10, 10);
+    }
+
+    @Override public boolean contains(Point2D.Double p) { return false; }
+    @Override public Object getTransformRestoreData() { return null; }
+    @Override public void restoreTransformTo(Object restoreData) {}
+    @Override public void transform(AffineTransform tx) {}
+    @Override public <T> void set(AttributeKey<T> key, T value) {}
+    @Override public <T> T get(AttributeKey<T> key) { return null; }
+    @Override public Map<AttributeKey<?>, Object> getAttributes() { return Collections.emptyMap(); }
+    @Override public Object getAttributesRestoreData() { return null; }
+    @Override public void restoreAttributesTo(Object restoreData) {}
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/bdd/ThenZOrder.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/bdd/ThenZOrder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 The authors and contributors of JHotDraw.
+ */
+package org.jhotdraw.draw.bdd;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ScenarioState.Resolution;
+import org.assertj.core.api.Assertions;
+import org.jhotdraw.draw.QuadTreeDrawing;
+import org.jhotdraw.draw.figure.Figure;
+
+import java.util.List;
+
+/**
+ * JGiven Then-stage: asserts z-order positions using AssertJ.
+ * Lab 6 — BDDLab (Software Maintenance portfolio).
+ */
+public class ThenZOrder extends Stage<ThenZOrder> {
+
+    @ExpectedScenarioState(resolution = Resolution.NAME)
+    QuadTreeDrawing drawing;
+
+    @ExpectedScenarioState(resolution = Resolution.NAME)
+    Figure figureA;
+
+    @ExpectedScenarioState(resolution = Resolution.NAME)
+    Figure figureC;
+
+    public ThenZOrder figure_A_is_at_the_front() {
+        List<Figure> children = drawing.getChildren();
+        Assertions.assertThat(children.get(children.size() - 1))
+                .as("figureA should be the topmost (last) child")
+                .isSameAs(figureA);
+        return self();
+    }
+
+    public ThenZOrder figure_C_is_at_the_back() {
+        Assertions.assertThat(drawing.getChild(0))
+                .as("figureC should be the bottommost (first) child")
+                .isSameAs(figureC);
+        return self();
+    }
+
+    public ThenZOrder figure_C_is_still_at_the_front() {
+        List<Figure> children = drawing.getChildren();
+        Assertions.assertThat(children.get(children.size() - 1))
+                .as("figureC should still be at the front")
+                .isSameAs(figureC);
+        return self();
+    }
+
+    public ThenZOrder figure_A_is_still_at_the_back() {
+        Assertions.assertThat(drawing.getChild(0))
+                .as("figureA should still be at the back")
+                .isSameAs(figureA);
+        return self();
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/bdd/WhenArrange.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/bdd/WhenArrange.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 The authors and contributors of JHotDraw.
+ */
+package org.jhotdraw.draw.bdd;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ScenarioState.Resolution;
+import org.jhotdraw.draw.QuadTreeDrawing;
+import org.jhotdraw.draw.figure.Figure;
+
+/**
+ * JGiven When-stage: performs z-order operations on the drawing.
+ * Lab 6 — BDDLab (Software Maintenance portfolio).
+ */
+public class WhenArrange extends Stage<WhenArrange> {
+
+    @ExpectedScenarioState(resolution = Resolution.NAME)
+    QuadTreeDrawing drawing;
+
+    @ExpectedScenarioState(resolution = Resolution.NAME)
+    Figure figureA;
+
+    @ExpectedScenarioState(resolution = Resolution.NAME)
+    Figure figureB;
+
+    @ExpectedScenarioState(resolution = Resolution.NAME)
+    Figure figureC;
+
+    public WhenArrange figure_A_is_sent_to_the_front() {
+        drawing.bringToFront(figureA);
+        return self();
+    }
+
+    public WhenArrange figure_C_is_sent_to_the_back() {
+        drawing.sendToBack(figureC);
+        return self();
+    }
+
+    public WhenArrange figure_C_is_sent_to_the_front() {
+        drawing.bringToFront(figureC);
+        return self();
+    }
+
+    public WhenArrange figure_A_is_sent_to_the_back() {
+        drawing.sendToBack(figureA);
+        return self();
+    }
+}

--- a/jhotdraw-core/src/test/java/org/jhotdraw/draw/figure/AbstractFigureNGTest.java
+++ b/jhotdraw-core/src/test/java/org/jhotdraw/draw/figure/AbstractFigureNGTest.java
@@ -24,14 +24,17 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.Map;
 import org.jhotdraw.draw.AttributeKey;
-import static org.testng.Assert.*;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import static org.junit.Assert.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
+ * Migrated from TestNG to JUnit 4 (behavior-preserving) so it runs under this module's
+ * surefire-junit47 provider alongside the JUnit/JGiven suites. The file keeps its original
+ * {@code *NGTest} name for traceability.
  *
  * @author tw
  */
@@ -48,15 +51,15 @@ public class AbstractFigureNGTest {
     public static void tearDownClass() throws Exception {
     }
 
-    @BeforeMethod
+    @Before
     public void setUpMethod() throws Exception {
     }
 
-    @AfterMethod
+    @After
     public void tearDownMethod() throws Exception {
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test(expected = IllegalStateException.class)
     public void testChangedWithoutWillChange() {
         new AbstractFigureImpl().changed();
     }
@@ -64,15 +67,15 @@ public class AbstractFigureNGTest {
     @Test
     public void testWillChangeChangedEvents() {
         AbstractFigure figure = new AbstractFigureImpl();
-        assertEquals(figure.getChangingDepth(), 0);
+        assertEquals(0, figure.getChangingDepth());
         figure.willChange();
-        assertEquals(figure.getChangingDepth(), 1);
+        assertEquals(1, figure.getChangingDepth());
         figure.willChange();
-        assertEquals(figure.getChangingDepth(), 2);
+        assertEquals(2, figure.getChangingDepth());
         figure.changed();
-        assertEquals(figure.getChangingDepth(), 1);
+        assertEquals(1, figure.getChangingDepth());
         figure.changed();
-        assertEquals(figure.getChangingDepth(), 0);
+        assertEquals(0, figure.getChangingDepth());
     }
 
     public class AbstractFigureImpl extends AbstractFigure {


### PR DESCRIPTION
Behavior-preserving refactoring of the Arrange feature (Send to Front/Back):

- **Extract Class**: duplicated anonymous undo edit in `BringToFrontAction` + `SendToBackAction` → one `ZOrderUndoableEdit` (`toFront` flag picks redo/undo direction).
- Narrowed wildcard imports; added JavaDoc.
- Added JUnit (`QuadTreeDrawingTest`) + JGiven BDD (`ArrangeZOrderTest`) tests; migrated `AbstractFigureNGTest` to JUnit 4.
- Added GitHub Actions CI (`maven.yml`, JDK 17).

Public API unchanged → `mvn -pl jhotdraw-core -am test`: **16 tests, 0 failures**.